### PR TITLE
Allow Shortcuts to be created placing files in a folder whose access does not require root

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.termux.widget"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 11
-        versionName "0.11"
+        versionCode 13
+        versionName "0.13"
     }
 
     signingConfigs {

--- a/app/src/main/java/com/termux/widget/TermuxWidgetService.java
+++ b/app/src/main/java/com/termux/widget/TermuxWidgetService.java
@@ -3,6 +3,8 @@ package com.termux.widget;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Environment;
+import android.util.Log;
 import android.widget.RemoteViews;
 import android.widget.RemoteViewsService;
 
@@ -14,7 +16,7 @@ import java.util.List;
 public final class TermuxWidgetService extends RemoteViewsService {
 
     @SuppressLint("SdCardPath")
-    public static final File SHORTCUTS_DIR = new File("/data/data/com.termux/files/home/.shortcuts");
+    public static File SHORTCUTS_DIR = new File("/data/data/com.termux/files/home/.shortcuts");
 
     public static final class TermuxWidgetItem {
 
@@ -29,6 +31,22 @@ public final class TermuxWidgetService extends RemoteViewsService {
             this.mFile = file.getAbsolutePath();
         }
 
+    }
+
+    @Override
+    public void onCreate() {
+        File[] strg = getApplicationContext().getExternalFilesDirs(null);
+        if (strg.length > 0) {
+            File dest = strg[0];
+            for (File f:strg) {
+                if (Environment.isExternalStorageRemovable(f)) {
+                    dest = f;
+                    break;
+                }
+            }
+            Log.i("termux", "new sh path " + dest.getAbsolutePath() + "/.shortcuts");
+            SHORTCUTS_DIR = new File(dest.getAbsolutePath() + "/.shortcuts");
+        }
     }
 
     @Override


### PR DESCRIPTION
I changed the folder where the shortcuts need to be placed using the folder returned by `getExternalFilesDirs` that usually returns `/sdcard/Android/data/com.termux.widget/files` or `/storage/emulated/0/Android/data/com.termux.widget/files`. Writing on this folder does not require root.