### PR TITLE
Feature/termux controls provider

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,3 +51,9 @@ task versionName {
     print android.defaultConfig.versionName
   }
 }
+
+dependencies {
+    // required for TermuxWidgetControlsProviderService
+    implementation "org.reactivestreams:reactive-streams:1.0.3"
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.10'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,16 @@
             android:name=".TermuxWidgetService"
             android:exported="false"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
+
+        <service
+            android:name=".TermuxWidgetControlsProviderService"
+            android:label="Termux Shortcuts"
+            android:permission="android.permission.BIND_CONTROLS">
+            <intent-filter>
+                <action android:name="android.service.controls.ControlsProviderService" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
 
         <service
             android:name=".TermuxWidgetControlsProviderService"
-            android:label="Termux Shortcuts"
+            android:label="@string/termux_shortcuts"
             android:permission="android.permission.BIND_CONTROLS">
             <intent-filter>
                 <action android:name="android.service.controls.ControlsProviderService" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/termux_appwidget_info" />
         </receiver>
+        <receiver android:name=".TermuxWidgetControlExecutorReceiver" />
 
         <activity
             android:name=".TermuxCreateShortcutActivity"

--- a/app/src/main/java/com/termux/widget/TermuxLaunchShortcutActivity.java
+++ b/app/src/main/java/com/termux/widget/TermuxLaunchShortcutActivity.java
@@ -42,26 +42,7 @@ public class TermuxLaunchShortcutActivity extends Activity {
 			finish();
 			return;
 		}
-
-		File clickedFile = new File(intent.getData().getPath());
-		TermuxWidgetProvider.ensureFileReadableAndExecutable(clickedFile);
-
-		// Do not use the intent data passed in, since that may be an old one with a file:// uri
-		// which is not allowed starting with Android 7.
-		Uri scriptUri = new Uri.Builder().scheme("com.termux.file").path(clickedFile.getAbsolutePath()).build();
-
-		Intent executeIntent = new Intent(TermuxWidgetProvider.ACTION_EXECUTE, scriptUri);
-		executeIntent.setClassName("com.termux", TermuxWidgetProvider.TERMUX_SERVICE);
-		if (clickedFile.getParentFile().getName().equals("tasks")) {
-			executeIntent.putExtra("com.termux.execute.background", true);
-			// Show feedback for executed background task.
-			String message = "Task executed: " + clickedFile.getName();
-			Toast toast = Toast.makeText(this, message, Toast.LENGTH_SHORT);
-			toast.setGravity(Gravity.CENTER, 0, 0);
-			toast.show();
-		}
-
-		TermuxWidgetProvider.startTermuxService(this, executeIntent);
+		TermuxWidgetProvider.handleTermuxShortcutExecuteIntent(this, intent);
 		finish();
 	}
 }

--- a/app/src/main/java/com/termux/widget/TermuxWidgetControlExecutorReceiver.java
+++ b/app/src/main/java/com/termux/widget/TermuxWidgetControlExecutorReceiver.java
@@ -3,12 +3,8 @@ package com.termux.widget;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 import android.util.Log;
-import android.view.Gravity;
 import android.widget.Toast;
-
-import java.io.File;
 
 import static com.termux.widget.TermuxLaunchShortcutActivity.TOKEN_NAME;
 import static com.termux.widget.TermuxLaunchShortcutActivity.getGeneratedToken;
@@ -23,24 +19,6 @@ public class TermuxWidgetControlExecutorReceiver extends BroadcastReceiver {
             Toast.makeText(context, R.string.bad_token_message, Toast.LENGTH_LONG).show();
             return;
         }
-
-        File shortcutFile = new File(intent.getData().getPath());
-        TermuxWidgetProvider.ensureFileReadableAndExecutable(shortcutFile);
-
-        // Do not use the intent data passed in, since that may be an old one with a file:// uri
-        // which is not allowed starting with Android 7.
-        Uri scriptUri = new Uri.Builder().scheme("com.termux.file").path(shortcutFile.getAbsolutePath()).build();
-
-        Intent executeIntent = new Intent(TermuxWidgetProvider.ACTION_EXECUTE, scriptUri);
-        executeIntent.setClassName("com.termux", TermuxWidgetProvider.TERMUX_SERVICE);
-        if (shortcutFile.getParentFile().getName().equals("tasks")) {
-            executeIntent.putExtra("com.termux.execute.background", true);
-            // Show feedback for executed background task.
-            String message = "Task executed: " + shortcutFile.getName();
-            Toast toast = Toast.makeText(context, message, Toast.LENGTH_SHORT);
-            toast.setGravity(Gravity.CENTER, 0, 0);
-            toast.show();
-        }
-        TermuxWidgetProvider.startTermuxService(context, executeIntent);
+        TermuxWidgetProvider.handleTermuxShortcutExecuteIntent(context, intent);
     }
 }

--- a/app/src/main/java/com/termux/widget/TermuxWidgetControlExecutorReceiver.java
+++ b/app/src/main/java/com/termux/widget/TermuxWidgetControlExecutorReceiver.java
@@ -1,0 +1,46 @@
+package com.termux.widget;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.util.Log;
+import android.view.Gravity;
+import android.widget.Toast;
+
+import java.io.File;
+
+import static com.termux.widget.TermuxLaunchShortcutActivity.TOKEN_NAME;
+import static com.termux.widget.TermuxLaunchShortcutActivity.getGeneratedToken;
+
+public class TermuxWidgetControlExecutorReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String token = intent.getStringExtra(TOKEN_NAME);
+        if (token == null || !token.equals(getGeneratedToken(context))) {
+            Log.w("termux", "Strange token: " + token);
+            Toast.makeText(context, R.string.bad_token_message, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        File shortcutFile = new File(intent.getData().getPath());
+        TermuxWidgetProvider.ensureFileReadableAndExecutable(shortcutFile);
+
+        // Do not use the intent data passed in, since that may be an old one with a file:// uri
+        // which is not allowed starting with Android 7.
+        Uri scriptUri = new Uri.Builder().scheme("com.termux.file").path(shortcutFile.getAbsolutePath()).build();
+
+        Intent executeIntent = new Intent(TermuxWidgetProvider.ACTION_EXECUTE, scriptUri);
+        executeIntent.setClassName("com.termux", TermuxWidgetProvider.TERMUX_SERVICE);
+        if (shortcutFile.getParentFile().getName().equals("tasks")) {
+            executeIntent.putExtra("com.termux.execute.background", true);
+            // Show feedback for executed background task.
+            String message = "Task executed: " + shortcutFile.getName();
+            Toast toast = Toast.makeText(context, message, Toast.LENGTH_SHORT);
+            toast.setGravity(Gravity.CENTER, 0, 0);
+            toast.show();
+        }
+        TermuxWidgetProvider.startTermuxService(context, executeIntent);
+    }
+}

--- a/app/src/main/java/com/termux/widget/TermuxWidgetControlsProviderService.java
+++ b/app/src/main/java/com/termux/widget/TermuxWidgetControlsProviderService.java
@@ -205,13 +205,12 @@ public class TermuxWidgetControlsProviderService extends ControlsProviderService
         return PendingIntent.getActivity(getBaseContext(), WIDGET_REQUEST_CODE, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
-    private Intent addShortcutFileExtrasToIntent(File file, Intent intent) {
+    private void addShortcutFileExtrasToIntent(File file, Intent intent) {
         String token = TermuxLaunchShortcutActivity.getGeneratedToken(getBaseContext());
         intent.putExtra(TOKEN_NAME, token);
 
         Uri scriptUri = new Uri.Builder().scheme("com.termux.file").path(file.getAbsolutePath()).build();
         intent.setData(scriptUri);
-        return intent;
     }
 
     private Intent createBroadcastIntentForShortcutFile(File file) {
@@ -246,7 +245,7 @@ public class TermuxWidgetControlsProviderService extends ControlsProviderService
             // max depth defined from TermuxWidgetService so using same here
             return;
         }
-        File[] files = dir.listFiles();
+        File[] files = dir.listFiles(TermuxWidgetService.SHORTCUT_FILES_FILTER);
 
         if (files == null) {
             return;

--- a/app/src/main/java/com/termux/widget/TermuxWidgetControlsProviderService.java
+++ b/app/src/main/java/com/termux/widget/TermuxWidgetControlsProviderService.java
@@ -1,0 +1,229 @@
+package com.termux.widget;
+
+import android.annotation.TargetApi;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.graphics.drawable.Icon;
+import android.net.Uri;
+import android.os.Build;
+import android.service.controls.Control;
+import android.service.controls.ControlsProviderService;
+import android.service.controls.DeviceTypes;
+import android.service.controls.actions.ControlAction;
+
+import org.reactivestreams.FlowAdapters;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.function.Consumer;
+
+import io.reactivex.Flowable;
+import io.reactivex.processors.ReplayProcessor;
+
+import static com.termux.widget.TermuxLaunchShortcutActivity.TOKEN_NAME;
+
+/**
+ * ControlProviderService for Android 11+ Device Control which allows running
+ * Termux Widget shortcuts from device Power Menu.
+ * See:
+ * https://developer.android.com/guide/topics/ui/device-control
+ */
+@TargetApi(Build.VERSION_CODES.R)
+public class TermuxWidgetControlsProviderService extends ControlsProviderService {
+    private static final int WIDGET_REQUEST_CODE = 2233;
+
+    private final ReplayProcessor<Control> mReplayProcessor = ReplayProcessor.create();
+
+    /**
+     * Creates the initial selection of all our shortcut widget controls that the user can add.
+     * Android system will subscribe to our flow to display items to user
+     * @return Flow.Publisher<Control>
+     */
+    @Override
+    public Flow.Publisher<Control> createPublisherForAllAvailable() {
+        List<File> shortcutFiles = createShortcutFilesList();
+        List<Control> controlList = new ArrayList<>();
+
+        for (File shortcutFile : shortcutFiles) {
+            Control control = createDefaultSelectableWidgetControl(shortcutFile);
+            controlList.add(control);
+        }
+        return FlowAdapters.toFlowPublisher(Flowable.fromIterable(controlList));
+    }
+
+    /**
+     * Creates the selection of widget controls that the user has added and adds the necessary
+     * PendingIntent to execute the widget action.
+     * Android system will subscribe to our flow to display items to user
+     * @param list List of widget control ids (shortcut paths) that user has added
+     * @return Flow.Publisher<Control>
+     */
+    @Override
+    public Flow.Publisher<Control> createPublisherFor(List<String> list) {
+        for (String shortcutFilePath : list) {
+            File shortcutFile = new File(shortcutFilePath);
+            Control control;
+
+            if (!shortcutFile.isFile() || !shortcutFile.exists()) {
+                control = createWidgetControlForInvalidShortcutFile(shortcutFile);
+            } else {
+                control = createWidgetControlForValidShortcutFile(shortcutFile);
+            }
+            mReplayProcessor.onNext(control);
+        }
+        return FlowAdapters.toFlowPublisher(mReplayProcessor);
+    }
+
+    /**
+     * Notify consumers that action was performed.
+     * @param controlId
+     * @param controlAction
+     * @param consumer
+     */
+    @Override
+    public void performControlAction(String controlId, ControlAction controlAction, Consumer<Integer> consumer) {
+        // our controls have no custom UI interaction, they only fire a command so
+        // we just need to notify consumer that we have handled successfully
+        consumer.accept(ControlAction.RESPONSE_OK);
+    }
+
+    /**
+     * Creates Control Widget that user can add, but is not already added
+     * @param shortcutFile
+     * @return Control
+     */
+    private Control createDefaultSelectableWidgetControl(File shortcutFile) {
+        PendingIntent emptyPendingIntent = createNoopPendingIntent();
+
+        return new Control.StatelessBuilder(shortcutFile.getAbsolutePath(), emptyPendingIntent)
+                .setTitle(shortcutFile.getName())
+                .setSubtitle(createSubtitle(shortcutFile))
+                .setCustomIcon(createDefaultIcon())
+                .setDeviceType(DeviceTypes.TYPE_UNKNOWN)
+                .build();
+    }
+
+    /**
+     * Creates Control widget that will display an error when interacted with (indicating
+     * that shortcut is invalid / missing).
+     * @param shortcutFile
+     * @return Control
+     */
+    private Control createWidgetControlForInvalidShortcutFile(File shortcutFile) {
+        // If user taps "Open App" in error popup, it will display the error in Termux session
+        PendingIntent pendingIntent = createPendingIntentForShortcutFile(shortcutFile);
+
+        return new Control.StatefulBuilder(shortcutFile.getAbsolutePath(), pendingIntent)
+                .setTitle(shortcutFile.getName())
+                .setSubtitle(createSubtitle(shortcutFile))
+                .setCustomIcon(createDefaultIcon())
+                .setDeviceType(DeviceTypes.TYPE_UNKNOWN)
+                .setStatus(Control.STATUS_NOT_FOUND) // will show native error popup on user interaction
+                .build();
+    }
+
+    /**
+     * Creates Control widget that will fire off commands from the shortcutFile.
+     * @param shortcutFile
+     * @return Control
+     */
+    private Control createWidgetControlForValidShortcutFile(File shortcutFile) {
+        PendingIntent pendingIntent = createPendingIntentForShortcutFile(shortcutFile);
+
+        return new Control.StatefulBuilder(shortcutFile.getAbsolutePath(), pendingIntent)
+                .setTitle(shortcutFile.getName())
+                .setSubtitle(createSubtitle(shortcutFile))
+                .setCustomIcon(createDefaultIcon())
+                .setDeviceType(DeviceTypes.TYPE_UNKNOWN)
+                .setStatus(Control.STATUS_OK)
+                .build();
+    }
+
+    /**
+     * Display shortcut file parent name as subtitle
+     * @param file
+     * @return String
+     */
+    private String createSubtitle(File file) {
+        return file.getParentFile() != null ? file.getParentFile().getName() : "???";
+    }
+
+    /**
+     * Use our launcher icon as default icon for our Control widgets
+     * @return Icon
+     */
+    private Icon createDefaultIcon() {
+        return Icon.createWithResource(getBaseContext(), R.drawable.ic_launcher);
+    }
+
+    /**
+     * Create PendingIntent that does nothing, but is required for Control builder as
+     * we cannot pass null there.
+     * @return PendingIntent
+     */
+    private PendingIntent createNoopPendingIntent() {
+        Intent emptyIntent = new Intent();
+        return PendingIntent.getActivity(getBaseContext(), 1, emptyIntent, 0);
+    }
+
+    /**
+     * Creates PendingIntent to run our widget shortcut file which will run via {@link TermuxLaunchShortcutActivity}
+     * @param file
+     * @return PendingIntent
+     */
+    private PendingIntent createPendingIntentForShortcutFile(File file) {
+        Intent intent = new Intent(getBaseContext(), TermuxLaunchShortcutActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        String token = TermuxLaunchShortcutActivity.getGeneratedToken(getBaseContext());
+        intent.putExtra(TOKEN_NAME, token);
+
+        Uri scriptUri = new Uri.Builder().scheme("com.termux.file").path(file.getAbsolutePath()).build();
+        intent.setData(scriptUri);
+        return PendingIntent.getActivity(getBaseContext(), WIDGET_REQUEST_CODE, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+    /**
+     * Recursively finds shortcut files starting from {@link TermuxWidgetService#SHORTCUTS_DIR}
+     * @return List<File>
+     */
+    private List<File> createShortcutFilesList() {
+        File shortcutDir = TermuxWidgetService.SHORTCUTS_DIR;
+
+        List<File> shortcutFiles = new ArrayList<>();
+        addShortcutFile(shortcutDir, shortcutFiles, 0);
+
+        // sort by file name
+        Collections.sort(shortcutFiles, (lhs, rhs) -> NaturalOrderComparator.compare(lhs.getName(), rhs.getName()));
+        return shortcutFiles;
+    }
+
+    /**
+     * Helper for recursively adding shortcut files.
+     * @param dir
+     * @param shortcutFiles
+     * @param depth
+     */
+    private void addShortcutFile(File dir, List<File> shortcutFiles, int depth) {
+        if (depth > 5) {
+            // max depth defined from TermuxWidgetService so using same here
+            return;
+        }
+        File[] files = dir.listFiles();
+
+        if (files == null) {
+            return;
+        }
+
+        for (File file : files) {
+            if (file.isDirectory()) {
+                addShortcutFile(file, shortcutFiles, depth + 1);
+            } else {
+                shortcutFiles.add(file);
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,5 +8,6 @@
     <string name="termux">Termux</string>
     <string name="scripts_reloaded">Termux shortcuts reloaded</string>
     <string name="bad_token_message">This shortcut has become invalid - remove and add again.</string>
+    <string name="termux_shortcuts">Termux Shortcuts</string>
 
 </resources>


### PR DESCRIPTION
Implements #54 Device Control Widgets
**(This is only for Android 11+)**
I have only tested on Google Pixel 5

![Screen Shot 2021-08-29 at 1 38 43 PM](https://user-images.githubusercontent.com/6166095/131261657-e686d41c-afb2-453d-97c8-ebc781d794e3.png)

Execution will exhibit same behavior as current home screen widgets. (i.e. any file placed in `.shortcuts/tasks` will run in background, all others in foreground.
* Exception: If script runs any ui action (ex: `termux-dialog`, `termux-toast`) it will not be visible until user exits the Device Control view.

## Error handling if script was removed / changed:

* Widget will show "Not found". Tapping on it will display this error dialog:

![Screen Shot 2021-08-29 at 1 40 18 PM](https://user-images.githubusercontent.com/6166095/131261710-f4a52b12-5095-4842-8ef5-5ee3876a0671.png)
and tapping "Open App" will display error in Termux window:
![Screen Shot 2021-08-29 at 1 41 21 PM](https://user-images.githubusercontent.com/6166095/131261734-89bae65b-faef-4e6c-b2ae-a2320e72146e.png)
