### PR TITLE
Remove replacement of '-' to ' ' in file names

### DIFF
--- a/app/src/main/java/com/termux/widget/TermuxWidgetService.java
+++ b/app/src/main/java/com/termux/widget/TermuxWidgetService.java
@@ -55,7 +55,7 @@ public final class TermuxWidgetService extends RemoteViewsService {
 
         public TermuxWidgetItem(File file, int depth) {
             this.mLabel = (depth > 0 ? (file.getParentFile().getName() + "/") : "")
-                    + file.getName().replace('-', ' ');
+                    + file.getName();
             this.mFile = file.getAbsolutePath();
         }
 


### PR DESCRIPTION
Label `tasks/start services.sh` looks ugly, `tasks/start-services.sh` looks much better

If I want `tasks/start services.sh` i will create file named like that