### PR TITLE
Fixed: Enable `desugar_jdk_libs` at 1.1.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,8 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
+
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
@@ -63,6 +65,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
+
     // required for TermuxWidgetControlsProviderService
     implementation "org.reactivestreams:reactive-streams:1.0.3"
     implementation "io.reactivex.rxjava2:rxjava:2.2.10"


### PR DESCRIPTION
- Necessary to fix this error while building Termux from source using the [local Maven repository guide](https://github.com/termux/termux-app/wiki/Termux-Libraries#forking-and-local-development):

```
1.  Dependency 'com.termux:termux-shared:0.118.0' requires core library desugaring to be enabled
    for :app.
```

- After this PR: https://github.com/termux/termux-app/pull/3619